### PR TITLE
Update render-link.html

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -122,7 +122,7 @@ either of these shortcodes in conjunction with this render hook.
 
     {{- /* Set attributes for anchor element. */}}
     {{- $attrs := dict "href" $u.String }}
-    {{- if and $u.IsAbs (ne (print "https://" $u.Hostname) site.BaseURL) }}
+    {{- if and $u.IsAbs (ne (print "https://" $u.Hostname) site.Home.Permalink) }}
         {{- /* Destination is external. */}}
         {{- $attrs = merge $attrs (dict "rel" "external") }}
     {{- else }}


### PR DESCRIPTION
> There is never a great reason to call .Site.BaseURL from a template. Hopefully we will deprecate that method at some point. Use the `absURL` and `absLangURL` functions instead.

[JMooring](https://discourse.gohugo.io/t/46692/4)

https://gohugo.io/methods/site/home/

