### PR TITLE
Update title-site.html

### DIFF
--- a/layouts/partials/nav/masthead/title-site.html
+++ b/layouts/partials/nav/masthead/title-site.html
@@ -1,6 +1,6 @@
 {{ with .Site.Title }}
     {{ $title := . | site.Home.RenderString }}
-    {{ $link := $.Site.BaseURL }}
+    {{ $link := $.Site.Home.Permalink }}
     {{ with $.Site.Params.logo }}
         {{ with resources.Get . }}
           <a class="ctrl__title ctrl__title--logo" href="{{ $link }}">


### PR DESCRIPTION
> There is never a great reason to call .Site.BaseURL from a template. Hopefully we will deprecate that method at some point. Use the `absURL` and `absLangURL` functions instead.

[JMooring](https://discourse.gohugo.io/t/46692/4)

https://gohugo.io/methods/site/home/

