### PR TITLE
Fix avoiding p-in-p when existing p has attribute

### DIFF
--- a/layouts/partials/wrap-p.html
+++ b/layouts/partials/wrap-p.html
@@ -1,4 +1,4 @@
-{{- if not ( strings.Contains . "<p>" ) }}
+{{- if not ( strings.Contains . "</p>" ) }}
   <p>{{ . }}</p>
 {{- else }}
   {{- . }}


### PR DESCRIPTION
When a Markdown block has an attribute:

Sample paragraph. It's really short
{.p-first}

we can't just search for \<p> because it will be a \<p class='p-first'>. We can, however, search for the closing tag \</p> instead and this resolves the issue.

Closes #129