### PR TITLE
Fix invalid use of figure in span

### DIFF
--- a/layouts/partials/authors/portrait-tiny.html
+++ b/layouts/partials/authors/portrait-tiny.html
@@ -1,7 +1,7 @@
 <ul class="author-list">
 {{- with .GetTerms "authors" }}
         {{- range . -}}
-            <li><span title="{{ .Title }}">{{- partial "img/portrait-tiny.html" .Page }}</span></li>
+            <li><div title="{{ .Title }}">{{- partial "img/portrait-tiny.html" .Page }}</div></li>
         {{- end }}
 {{- end }}
 </ul>


### PR DESCRIPTION
Switch the wrapper span to div in order to build compliant HTML.

Closes #130