### PR TITLE
Protect against link in link with summaries

### DIFF
--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -1,8 +1,8 @@
 {{- with .Summary -}}
-    {{- partial "wrap-p" (partial "replacements.html" .) }}
+    {{- partial "wrap-p" (partial "replacements.html" . | htmlUnescape | plainify ) }}
 {{- else -}}
     {{- with .Description -}}
-      <p>{{- partial "replacements.html" ( . | site.Home.RenderString ) -}}</p>
+      <p>{{- partial "replacements.html" ( . | htmlUnescape | plainify | site.Home.RenderString ) -}}</p>
     {{ else }}
         {{ warnf "Unable to print summary. No summary or description found for %v." . }}
     {{- end -}}

--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -2,7 +2,7 @@
     {{- partial "wrap-p" (partial "replacements.html" . | htmlUnescape | plainify ) }}
 {{- else -}}
     {{- with .Description -}}
-      <p>{{- partial "replacements.html" ( . | htmlUnescape | plainify | site.Home.RenderString ) -}}</p>
+      <p>{{- partial "replacements.html" ( . | site.Home.RenderString| htmlUnescape | plainify ) -}}</p>
     {{ else }}
         {{ warnf "Unable to print summary. No summary or description found for %v." . }}
     {{- end -}}


### PR DESCRIPTION
There was a warning in the notes that links don't work in summaries, but it is easy, especially when bringing in old content, to have a first paragraph that has a link. And, in any event, this should be protected from by the template rather than a potential source of user error that breaks the theme.

We use .Summary | htmlUnescape | plainify to resolve this (and likewise for .Description).

Closes #137 