### PR TITLE
Make blog and news title gradient selectable

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,7 +1,8 @@
 {{- define "main" -}}
+{{- $blogGradient := site.Params.blogGradient | default page.Params.blogGradient | default "dark--bluered" -}}
   <div id="l-content-box" class="l-box l-box--full">
     <header class="page-header">
-      <div class="title title--dark title--dark--bluered padding-full">
+      <div class="title title--dark title--{{ $blogGradient }} padding-full">
           {{ partial "file/vscode_start.html" . }}
           {{ partial "title/title.html" . }}
           {{ partial "file/vscode_end.html" . }}

--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -1,4 +1,5 @@
 {{- define "main" -}}
+{{- $newsGradient := site.Params.newsGradient | default page.Params.newsGradient | default "dark--bluegreen" -}}
     <div id="l-content-box" class="l-box l-box--full">
         <div>
             {{- with .Content }}
@@ -7,7 +8,7 @@
             </div>
             {{- end }}
             <header class="page-header">
-                <div class="title title--sans title--dark title--dark--bluegreen padding-full">
+                <div class="title title--sans title--dark title--{{ $newsGradient }} padding-full">
                     {{- partial "file/vscode_start.html" . }}
                     {{- partial "title/title.html" . }}
                     {{- partial "file/vscode_end.html" . }}


### PR DESCRIPTION
When using custom colour schemes one might not want the default gradients for the news and blog titles, so make these each a param (site first, then page, then current default)