### PR TITLE
correct site.isServer deprecation

### DIFF
--- a/_vendor/github.com/bowman2001/hugo-mod-image/layouts/partials/mod-img/helper/debug.html
+++ b/_vendor/github.com/bowman2001/hugo-mod-image/layouts/partials/mod-img/helper/debug.html
@@ -1,4 +1,4 @@
-{{- if and site.IsServer site.Data.modImg.debug }}
+{{- if and hugo.IsServer site.Data.modImg.debug }}
 <span>
     <pre style="max-width: 40rem; margin: 0 auto; font-size: 10px; line-height: 1.2; background-color: #ddd; overflow-x: auto">
     {{- print (transform.Remarshal "toml" . ) -}}


### PR DESCRIPTION
other instances of .Site.IsServer were caught and updated as required the vendor/.../helper/debug.html file still had a site.IsServer instance that throws errors on newer versions of hugo